### PR TITLE
Updating lookup condition for key in redis for cache class

### DIFF
--- a/lib/common/cache.rb
+++ b/lib/common/cache.rb
@@ -38,7 +38,7 @@ class Cache
           redis.expire(k(key), expire_in.to_i)
         end
         idx += 1
-      end until redis.exists(k(key))
+      end until redis.exists(k(key)) != 0
     end
 
     value

--- a/lib/common/cache.rb
+++ b/lib/common/cache.rb
@@ -37,8 +37,9 @@ class Cache
           redis.set(k(key), value)
           redis.expire(k(key), expire_in.to_i)
         end
+
         idx += 1
-      end until redis.exists(k(key)) != 0
+      end until redis_key_exists?(redis, k(key))
     end
 
     value
@@ -57,6 +58,14 @@ class Cache
 
   def k(key)
     CacheKey[@namespace + "/" + key]
+  end
+
+  # this function is needed for legacy compatibility
+  def redis_key_exists?(redis, key)
+    rv_class = redis.exists(key).class
+    return redis.exists(key) if [TrueClass, FalseClass].include? rv_class
+
+    return redis.exists(key) != 0
   end
 
 end

--- a/lib/common/module_registry.rb
+++ b/lib/common/module_registry.rb
@@ -39,4 +39,12 @@ class ModuleRegistry
     rv
   end
 
+  def remove registry_module
+    @all.delete(registry_module.to_s)
+  end
+
+  def truncate
+    @all = {}
+  end
+
 end

--- a/lib/infosig-utils.rb
+++ b/lib/infosig-utils.rb
@@ -1,5 +1,5 @@
 module InfoSigUtils
-  VERSION='1.0.0'
+  VERSION='1.0.1'
   ROOT = File.dirname(__FILE__)
 end
 

--- a/lib/infosig-utils.rb
+++ b/lib/infosig-utils.rb
@@ -1,5 +1,5 @@
 module InfoSigUtils
-  VERSION='1.0.1'
+  VERSION='1.0.2'
   ROOT = File.dirname(__FILE__)
 end
 


### PR DESCRIPTION
With redis version updated with upgrade of sidekiq, it seems that funcionality of `redis.exists()` changed and it gives integer 0 if key doesn't exist in cache, older version was returning boolean. This fixes new version while staying compatible with the older one.