### PR TITLE
NK/test-log-output-cleanup

### DIFF
--- a/lib/common/app_logger.rb
+++ b/lib/common/app_logger.rb
@@ -37,17 +37,20 @@ class AppLogger
     self.log_level = old_log_level
   end
 
-  def self.filtered_log_level log_lvl_msg_array
-    raise ArgumentError.new("Array must contain exactly 2 elements") if log_lvl_msg_array.length != 2
-    raise ArgumentError.new("First element must be one of the following: #{LOG_LEVELS.keys}") if !LOG_LEVELS.has_key?(log_lvl_msg_array[0])
+  def self.filtered_log_level *args
+    args = args[0] if args[0].is_a?(Array)
+    raise ArgumentError.new("There must be at least 2 elements present") if args.length < 2
+    text_msg = args.pop
+    raise ArgumentError.new("First element must be one of the following: #{LOG_LEVELS.keys}") unless (args - LOG_LEVELS.keys).empty?
+    raise ArgumentError.new("Last element must be a string message") unless text_msg.is_a?(String)
 
     old_log_level = self.log_level
-    self.log_level = log_lvl_msg_array[0]
-    self.log_message = log_lvl_msg_array[1]
+    self.log_level = args
+    self.log_message = text_msg
     yield
   ensure
     self.log_level = old_log_level
-    self.log_message = nil
+    self.log_message = []
   end
 
   LOG_LEVELS = {
@@ -105,10 +108,18 @@ class AppLogger
   end
 
   def log_filtered_object msg_log_level, object, log_message
-    return nil if numeric_log_level(msg_log_level) == numeric_log_level(log_level) && object.include?(log_message)
+    self.log_level = [self.log_level] unless self.log_level.is_a?(Array)
+    self.log_level.each do |level|
+      next unless object_should_be_logged_for_log_level?(msg_log_level, level, log_message, object)
+      return nil
+    end
 
     log_stout object, msg_log_level
     nil
+  end
+
+  def object_should_be_logged_for_log_level?(msg_log_level, level, log_message, object)
+    numeric_log_level(msg_log_level) == numeric_log_level(level) && object.include?(log_message)
   end
 
   def log_stout object, msg_log_level

--- a/test/unit/app_logger_test.rb
+++ b/test/unit/app_logger_test.rb
@@ -1,0 +1,61 @@
+require 'test_helpers'
+
+class AppLoggerTest < UnitTest
+
+  def test_filtered_log_level_array_size
+    assert_raises ArgumentError do |exception|
+      AppLogger.filtered_log_level([:one_element])
+      assert_equal exception, 'Array must contain exactly 2 elements'
+    end
+  end
+
+  def test_filtered_log_level_error_element
+    assert_raises ArgumentError do |exception|
+      AppLogger.filtered_log_level([:weird_error, 'Error message'])
+      assert_equal exception, "First element must be one of the following: #{LOG_LEVELS.keys}"
+    end
+  end
+
+  def test_filtered_log_level_wrong_message
+    output, _ = capture_io do
+      AppLogger.filtered_log_level([:error, 'Test message']) do
+        begin
+          raise ArgumentError.new 'Test'
+        rescue Exception => e
+          mock_backtrace e, :error
+        end
+      end
+    end
+
+    assert_equal true, output.include?("[error] ArgumentError Test\n")
+  end
+
+  def test_filtered_log_level_wrong_severity
+    output, _ = capture_io do
+      AppLogger.filtered_log_level([:error, 'Test message']) do
+        begin
+          raise ArgumentError.new 'Test message'
+        rescue Exception => e
+          mock_backtrace e, :warn
+        end
+      end
+    end
+
+    assert_equal true, output.include?("[warn] ArgumentError Test message\n")
+  end
+
+
+private
+
+  def mock_backtrace e, severity
+    backtrace = e.backtrace
+
+    backtrace.map! do |line|
+      line
+    end
+
+    output = "#{e.class} #{e.message}\n"
+    output += backtrace.join("\n")
+    AppLogger.send(severity, output)
+  end
+end


### PR DESCRIPTION
This PR was made so all tests where `AppLogger.with_log_level(:silence)` in Infoswitch/Gateway are used to see what's a better approach. In this PR, I have created a new method that takes 2 elements in an array (severity and message) and checks if both elements match the excepted `error/warning/debug` etc... If just one of them does not match the excepted stout, the logger if write the message on a terminal/console. Otherwise it will not.

This was made so if certain errors occur during the development that are not expected in a particular test, the Logger will print it out and we will be able to larger control on error handling as well as in debugging process.